### PR TITLE
Fix truncated URL bug

### DIFF
--- a/src/targets.ts
+++ b/src/targets.ts
@@ -61,7 +61,13 @@ export const addSectionsToTargets = async (
     const sectionTargets = prioritizedMatchedSectionTargets(sections.slice(1), searchString);
     targets.push(...sectionTargets.map((section) => ({ project, section })));
     // 2. add default section at end of list
-    targets.push({ project, section: sections[0] });
+    if (project != null) {
+      // only push the inbox if they explicitly listed a project -
+      // there's already an item added at the end for the user task
+      // list, and chances are the section hint wasn't intentional
+      // anyway.
+      targets.push({ project, section: sections[0] });
+    }
   }
 };
 


### PR DESCRIPTION
When we saw http://www.foo.com, Filer looked in the user task list for
a seciton matching 'com', didn't find one, but still suggested that
http://www.foo. be filed into My Tasks / Recently assigned.